### PR TITLE
README.rst: Try adding unindented line at end

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -76,3 +76,4 @@ Install with ``pip``
 
     $ pip install geojsonio
 
+That's all folks!


### PR DESCRIPTION
Taking a wild guess that maybe PyPI is not liking the RST because it ends in the middle of an indented block. 

I think docutils likes to see an unindented line to finish each block. 

Wild guess...