### PR TITLE
Fix _make_gist by providing github token through command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ Options:
 
     --print prints the url rather than opening it
     --domain="http://custominstancedomain.com/"
+    --github-token Github token used to create gist
 
 Installation
 ------------

--- a/tests/test_geojsonio.py
+++ b/tests/test_geojsonio.py
@@ -128,7 +128,8 @@ def test_factory_gist(features):
         class Dummy(object):
             id = 'abc123'
         MockInstance.return_value = Dummy()
-        url = geojsonio.make_url(contents, size_for_gist=size-1)
+        url = geojsonio.make_url(contents, size_for_gist=size-1,
+                                 github_token='my_token')
 
     assert url == geojsonio.gist_url(Dummy.id)
 
@@ -142,6 +143,6 @@ def test_factory_force_gist(features):
             id = 'abc123'
         MockInstance.return_value = Dummy()
         url = geojsonio.make_url(contents, size_for_gist=size+1,
-                                 force_gist=True)
+                                 force_gist=True, github_token='my_token')
 
     assert url == geojsonio.gist_url(Dummy.id)


### PR DESCRIPTION
Github does not allow anonymous gist creation, so we have to provide an identification token. This is done using command line parameter ("-t", "--github-token")
To create a token, go to https://github.com/settings/tokens